### PR TITLE
claim.js - fix more than 256 requests into a separate 5 dot requests

### DIFF
--- a/claim.js
+++ b/claim.js
@@ -93,13 +93,21 @@ function p(data) {
   return;
 }
 
-
 function load5dot() {
   var query = "";
   for (var i in claims) {
     var claim = claims[i];
     var commit = claim.Commitment.substring(0, 2*9);
     query += commit;
+    // every 256 commits we fire a separate filtering request - this is needed because the server does have limited capacity
+    if ((i % 256) == 255) {
+      claimsURL = claimsDomain + "/00000001.0000000000000000.00000009.9999999999999999." + query + ".js";
+      let html = document.createElement("script");
+      html.src = claimsURL;
+      document.body.append(html);
+      //reset query
+      query = "";
+    }
   }
   claimsURL = claimsDomain + "/00000001.0000000000000000.00000009.9999999999999999." + query + ".js";
   let html = document.createElement("script");


### PR DESCRIPTION
Every 256 commits we fire a separate filtering request - this is needed because the server does have limited capacity

Actually the server supports up to 65536 commits, but over 256 commits it could start responding bloom filters which we don't support here.